### PR TITLE
feat(validation): internal checks and preemption inference; integrate into ValidationAgent; tests

### DIFF
--- a/app/agents/validation_agent.py
+++ b/app/agents/validation_agent.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 from .base import Agent
+from ..core.validation_rules import run_internal_checks
 
 
 class ValidationAgent(Agent):
@@ -13,6 +14,11 @@ class ValidationAgent(Agent):
         super().__init__("validation_agent")
 
     def run(self, jurisdiction_file: Path, patch_file: Path) -> Tuple[bool, Dict]:
+        # First run internal checks for quick feedback
+        ok_internal, details_internal = run_internal_checks(patch_file, str(jurisdiction_file))
+        if not ok_internal:
+            return False, {"internal": details_internal}
+        # Then attempt external schema validator if present
         try:
             proc = subprocess.run([
                 "python", "tools/validate_matrix.py", "--file", str(jurisdiction_file), "--input", str(patch_file)
@@ -21,7 +27,11 @@ class ValidationAgent(Agent):
             details = {
                 "stdout": proc.stdout,
                 "stderr": proc.stderr,
+                "internal": details_internal,
             }
             return success, details
+        except FileNotFoundError:
+            # If external tool not available, rely on internal checks
+            return True, {"internal": details_internal, "warning": "External validator not found"}
         except Exception as e:
             return False, {"error": str(e)}

--- a/app/core/validation_rules.py
+++ b/app/core/validation_rules.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+
+def load_patch(patch_path: Path) -> Dict[str, Any]:
+    return json.loads(patch_path.read_text())
+
+
+def save_patch(patch_path: Path, data: Dict[str, Any]) -> None:
+    patch_path.write_text(json.dumps(data, indent=2))
+
+
+def check_citations(patch: Dict[str, Any]) -> List[str]:
+    """Return list of citation-related errors.
+    Minimal rule: if `ban_the_box.applies` is true, require at least one `citations.laws` entry.
+    """
+    errors: List[str] = []
+    btb = (patch or {}).get("ban_the_box", {})
+    applies = btb.get("applies")
+    citations = (patch or {}).get("citations", {})
+    laws = citations.get("laws") if isinstance(citations, dict) else None
+    if applies is True:
+        if not isinstance(laws, list) or len(laws) == 0:
+            errors.append("When ban_the_box.applies is true, citations.laws must contain at least one source")
+    return errors
+
+
+essential_fields = ["jurisdiction", "last_updated"]
+
+
+def check_required_fields(patch: Dict[str, Any]) -> List[str]:
+    errs: List[str] = []
+    for f in essential_fields:
+        if f not in patch or patch[f] in (None, ""):
+            errs.append(f"Missing required field: {f}")
+    return errs
+
+
+def maybe_infer_preemption(patch: Dict[str, Any], jurisdiction_path: str) -> Tuple[Dict[str, Any], List[str]]:
+    """Heuristic: If city jurisdiction, ban_the_box.applies is false, and citations.laws includes a state URL,
+    then add preemptions.preempted_by = ["state"]. Returns (modified_patch, notes)."""
+    notes: List[str] = []
+    data = dict(patch)
+    if "/city/" in jurisdiction_path:
+        btb = data.get("ban_the_box", {})
+        applies = btb.get("applies")
+        citations = (data or {}).get("citations", {})
+        laws = citations.get("laws") if isinstance(citations, dict) else []
+        has_state_source = any(isinstance(x, str) and (".state." in x or "/codes/" in x or "state." in x) for x in laws)
+        if applies is False and has_state_source:
+            pre = data.get("preemptions") or {}
+            preempted_by = set(pre.get("preempted_by") or [])
+            preempted_by.add("state")
+            pre["preempted_by"] = sorted(preempted_by)
+            data["preemptions"] = pre
+            notes.append("Inferred preemption: city preempted by state for ban_the_box")
+    return data, notes
+
+
+def run_internal_checks(patch_path: Path, jurisdiction_path: str, auto_fix_preemption: bool = True) -> Tuple[bool, Dict[str, Any]]:
+    data = load_patch(patch_path)
+    errors: List[str] = []
+    notes: List[str] = []
+
+    errors.extend(check_required_fields(data))
+    errors.extend(check_citations(data))
+
+    if auto_fix_preemption:
+        new_data, pre_notes = maybe_infer_preemption(data, jurisdiction_path)
+        if new_data != data:
+            save_patch(patch_path, new_data)
+            data = new_data
+            notes.extend(pre_notes)
+
+    ok = len(errors) == 0
+    details = {"errors": errors, "notes": notes}
+    return ok, details

--- a/app/tests/test_validation_rules.py
+++ b/app/tests/test_validation_rules.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.core.validation_rules import check_citations, check_required_fields, maybe_infer_preemption, run_internal_checks
+
+
+def test_required_and_citations(tmp_path: Path):
+    patch = {
+        "jurisdiction": "unified/city/test.json",
+        "ban_the_box": {"applies": True},
+        "citations": {"laws": []},
+    }
+    p = tmp_path / "patch.json"
+    p.write_text(json.dumps(patch))
+    ok, details = run_internal_checks(p, "unified/city/test.json")
+    assert not ok
+    assert any("citations" in e for e in details["errors"]) and any("Missing required field" in e for e in details["errors"]) 
+
+
+def test_infer_preemption(tmp_path: Path):
+    patch = {
+        "jurisdiction": "unified/city/test.json",
+        "ban_the_box": {"applies": False},
+        "citations": {"laws": ["https://example.state.codes/abc"]},
+        "last_updated": "2024-01-01",
+    }
+    p = tmp_path / "patch.json"
+    p.write_text(json.dumps(patch))
+    ok, details = run_internal_checks(p, "unified/city/test.json")
+    assert ok
+    updated = json.loads(p.read_text())
+    assert updated.get("preemptions", {}).get("preempted_by") == ["state"]


### PR DESCRIPTION
Adds internal validation checks and integrates them with the ValidationAgent before running external validator.

- Required fields check (jurisdiction, last_updated)
- Citations rule: require at least one law source when ban_the_box.applies is true
- Preemption heuristic (city preempted by state) auto-fix with notes
- Tests for rules and inference

Closes #3