### PR TITLE
Make datetimes timezone-aware; fix OpenAIEmbeddings compat; add langchain-openai; clean test warnings

### DIFF
--- a/app/agents/extraction_agent.py
+++ b/app/agents/extraction_agent.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Any, Dict, List, Optional
 
 from langchain.prompts import ChatPromptTemplate
@@ -74,7 +74,7 @@ class ExtractionAgent(Agent):
         if self.llm is None:
             # Offline mode: return skeleton only
             data = dict(schema_skeleton)
-            data["last_updated"] = datetime.utcnow().date().isoformat()
+            data["last_updated"] = datetime.now(UTC).date().isoformat()
             return data
 
         response = self.llm.invoke(message)
@@ -82,5 +82,5 @@ class ExtractionAgent(Agent):
             data = json.loads(response.content)
         except Exception:
             data = dict(schema_skeleton)
-        data["last_updated"] = datetime.utcnow().date().isoformat()
+        data["last_updated"] = datetime.now(UTC).date().isoformat()
         return data

--- a/app/agents/sourcing_agent.py
+++ b/app/agents/sourcing_agent.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Dict, List, Optional
 
 import httpx
@@ -58,7 +58,7 @@ class SourcingAgent(Agent):
             "title": doc.title,
             "published_at": doc.published_at,
             "jurisdiction_tags": doc.jurisdiction_tags,
-            "ingested_at": datetime.utcnow().isoformat(),
+            "ingested_at": datetime.now(UTC).isoformat(),
         }
 
     def add_to_vector(self, docs: List[SourceDocument]) -> None:

--- a/app/agents/task_manager.py
+++ b/app/agents/task_manager.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from typing import Optional
-from datetime import datetime
+from datetime import datetime, UTC
 
 from .base import Agent
 from ..core.queue import ResearchQueue
@@ -20,7 +20,11 @@ class TaskManagerAgent(Agent):
         self.logger = setup_logger("task_manager")
 
     def insert_task(self, jurisdiction_path: str, priority: int = 0) -> None:
-        task = ResearchTask(jurisdiction_path=jurisdiction_path, priority=priority, inserted_at=datetime.utcnow())
+        task = ResearchTask(
+            jurisdiction_path=jurisdiction_path,
+            priority=priority,
+            inserted_at=datetime.now(UTC),
+        )
         self.queue.add_task(task)
 
     def next(self, base_dir: Path | None = None) -> Optional[ResearchTask]:

--- a/app/core/db.py
+++ b/app/core/db.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 from typing import Optional
 
 from sqlalchemy import JSON, Column, DateTime, Integer, String, create_engine
@@ -17,8 +17,8 @@ class JurisdictionRun(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     jurisdiction_path: Mapped[str] = mapped_column(String, index=True)
     status: Mapped[str] = mapped_column(String, default="pending")
-    started_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
-    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime, nullable=True)
+    started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
     metrics: Mapped[Optional[dict]] = mapped_column(JSON, nullable=True)
     error: Mapped[Optional[str]] = mapped_column(String, nullable=True)
 
@@ -37,6 +37,6 @@ def record_run(database_url: str, jurisdiction_path: str, status: str, metrics: 
     with Session(engine) as session:
         run = JurisdictionRun(jurisdiction_path=jurisdiction_path, status=status, metrics=metrics, error=error)
         if status == "completed":
-            run.completed_at = datetime.utcnow()
+            run.completed_at = datetime.now(UTC)
         session.add(run)
         session.commit()

--- a/app/core/vector_store.py
+++ b/app/core/vector_store.py
@@ -35,13 +35,22 @@ class VectorStore:
         self._use_faiss = bool(FAISS is not None and HAS_FAISS_NATIVE)
         self._lock = FileLock(str(self.index_path) + ".lock")
         if api_key and OpenAIEmbeddings is not None:
-            self.embeddings = OpenAIEmbeddings(
-                api_key=api_key if hasattr(OpenAIEmbeddings, "api_key") else api_key,  # type: ignore
-                openai_api_key=api_key if hasattr(OpenAIEmbeddings, "openai_api_key") else None,  # type: ignore
-                model="text-embedding-3-large",
-                base_url=base_url if hasattr(OpenAIEmbeddings, "base_url") else None,  # type: ignore
-                openai_api_base=base_url if hasattr(OpenAIEmbeddings, "openai_api_base") else None,  # type: ignore
-            )
+            # Build kwargs compatible with the installed embeddings package
+            kwargs: dict = {"model": "text-embedding-3-large"}
+            module_name = getattr(OpenAIEmbeddings, "__module__", "")
+            if module_name.startswith("langchain_openai"):
+                # Newer package
+                if api_key:
+                    kwargs["api_key"] = api_key
+                if base_url:
+                    kwargs["base_url"] = base_url
+            else:
+                # Older community wrapper
+                if api_key:
+                    kwargs["openai_api_key"] = api_key
+                if base_url:
+                    kwargs["openai_api_base"] = base_url
+            self.embeddings = OpenAIEmbeddings(**kwargs)  # type: ignore
         else:
             # Offline deterministic embeddings for tests/dev
             self.embeddings = LocalHashEmbeddings()

--- a/app/dashboard/api.py
+++ b/app/dashboard/api.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from ..core.queue import ResearchQueue
 from ..core.types import ResearchTask
 from ..core.paths import project_root
-from datetime import datetime
+from datetime import datetime, UTC
 
 router = APIRouter(prefix="/api")
 
@@ -23,5 +23,11 @@ async def enqueue(req: EnqueueRequest):
     queue = ResearchQueue(qpath)
     queue.load()
     priority = req.priority if req.priority is not None else 0
-    queue.add_task(ResearchTask(jurisdiction_path=req.jurisdiction_path, priority=priority, inserted_at=datetime.utcnow()))
+    queue.add_task(
+        ResearchTask(
+            jurisdiction_path=req.jurisdiction_path,
+            priority=priority,
+            inserted_at=datetime.now(UTC),
+        )
+    )
     return {"status": "queued", "jurisdiction_path": req.jurisdiction_path, "priority": priority}

--- a/app/tests/test_queue.py
+++ b/app/tests/test_queue.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 from app.core.queue import ResearchQueue
 from app.core.types import ResearchTask
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def test_queue_roundtrip(tmp_path: Path):
@@ -13,8 +13,8 @@ def test_queue_roundtrip(tmp_path: Path):
     queue.load()
     assert queue.tasks == []
 
-    queue.add_task(ResearchTask("unified/state/ca.json", 5, datetime.utcnow()))
-    queue.add_task(ResearchTask("unified/city/sf.json", 2, datetime.utcnow()))
+    queue.add_task(ResearchTask("unified/state/ca.json", 5, datetime.now(UTC)))
+    queue.add_task(ResearchTask("unified/city/sf.json", 2, datetime.now(UTC)))
 
     queue.sort_by_priority()
     t = queue.next_task()

--- a/app/tests/test_queue_priority.py
+++ b/app/tests/test_queue_priority.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, UTC
 from pathlib import Path
 
 from app.core.queue import ResearchQueue
@@ -22,8 +22,8 @@ def test_priority_by_gaps(tmp_path: Path):
 
     q = ResearchQueue(qpath)
     q.load()
-    q.add_task(ResearchTask("unified/low.json", priority=1, inserted_at=datetime.utcnow()))
-    q.add_task(ResearchTask("unified/high.json", priority=1, inserted_at=datetime.utcnow()))
+    q.add_task(ResearchTask("unified/low.json", priority=1, inserted_at=datetime.now(UTC)))
+    q.add_task(ResearchTask("unified/high.json", priority=1, inserted_at=datetime.now(UTC)))
 
     # high is missing last_updated so should come first
     t = q.next_task(base_dir=base)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ requires-python = ">=3.10"
 dependencies = [
   "langchain>=0.2.12",
   "langchain-community>=0.2.10",
+  "langchain-openai>=0.1.0",
   "tiktoken>=0.7.0",
   "fastapi>=0.111.0",
   "uvicorn>=0.30.0",


### PR DESCRIPTION
This PR makes our time handling and embeddings init robust and removes test warnings.

Changes:
- Datetimes everywhere: replace deprecated `datetime.utcnow()` with `datetime.now(UTC)` and normalize queue timestamps to avoid naive/aware comparisons.
- Vector store: fix `OpenAIEmbeddings` initialization to support both `langchain_openai` and `langchain_community` variants without validation errors.
- SQLAlchemy models: enable timezone-aware `DateTime(timezone=True)` and set UTC defaults.
- Dependencies: add `langchain-openai` to `pyproject.toml`.
- Tests: use timezone-aware datetimes.

Result:
- `pytest` is fully green locally with no warnings.

